### PR TITLE
feat: rename app.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ There are some steps and specifications required to build a theme.
 
 First, get familiar with the data types ingested by a resume template. These can be found documented
 in
-[src/types/index.ts](https://github.com/missionmike/ampdresume-theme/blob/main/src/types/index.ts)
+[src/types/index.ts](https://github.com/mission-minded-llc/ampdresume-theme/blob/main/src/types/index.ts)
 
 ### Folder Structure
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-# OpenResume Theme
+# Amp'd Resume Theme
 
-[![codecov](https://codecov.io/gh/missionmike/openresume-theme/graph/badge.svg?token=HGZ6NME2HH)](https://codecov.io/gh/missionmike/openresume-theme)
+[![codecov](https://codecov.io/gh/missionmike/ampdresume-theme/graph/badge.svg?token=HGZ6NME2HH)](https://codecov.io/gh/missionmike/ampdresume-theme)
 
 Anyone can contribute their own frontend theme design and implementation for
-[OpenResume](https://www.openresume.org).
+[Amp'd Resume](https://www.ampdresume.com).
 
-Browse the published themes available here: https://theme.openresume.org/
+Browse the published themes available here: https://theme.ampdresume.com/
 
 ## The Project
 
-While the [OpenResume](https://www.openresume.org) backend and infrastructure is closed-source, the
-frontend templates for resume UIs and PDF exports are now open-source!
+While the [Amp'd Resume](https://www.ampdresume.com) backend and infrastructure is closed-source,
+the frontend templates for resume UIs and PDF exports are now open-source!
 
 ### What does this mean?
 
@@ -21,7 +21,7 @@ libraries needed.
 ### How can I contribute?
 
 To contribute, fork this repository, spin up on localhost to develop your theme, then open a pull
-request back to this main repository to see your theme available live on www.openresume.org once
+request back to this main repository to see your theme available live on www.ampdresume.com once
 it's merged.
 
 ## Developer Setup
@@ -41,8 +41,8 @@ To develop locally, first fork this repository and follow these steps:
 2. When your work is done on this branch, open a pull request into the original repository's
    `develop` branch.
 3. After the theme is merged into the `develop` branch, you should be able to view it live on
-   https://themetest.openresume.org as well as access the theme for testing on
-   https://test.openresume.org (only allow-listed members can sign in here, please request access).
+   https://themetest.ampdresume.com as well as access the theme for testing on
+   https://test.ampdresume.com (only allow-listed members can sign in here, please request access).
 4. From there, the theme will be merged to `main` branch, deployed to production and made available
    to all users!
 
@@ -54,7 +54,7 @@ There are some steps and specifications required to build a theme.
 
 First, get familiar with the data types ingested by a resume template. These can be found documented
 in
-[src/types/index.ts](https://github.com/missionmike/openresume-theme/blob/main/src/types/index.ts)
+[src/types/index.ts](https://github.com/missionmike/ampdresume-theme/blob/main/src/types/index.ts)
 
 ### Folder Structure
 
@@ -155,7 +155,7 @@ your own `sampleData.json` and `sampleData.ts` files within your `src/theme/[the
 Then, ensure they're imported in the `src/app/theme/[themeName]/ResumeView.tsx` and
 `src/app/theme/[themeName]/PDFView.tsx` files to be passed into your example page.
 
-If you want to base your sample data off a real resume from openresume.org, visit the
+If you want to base your sample data off a real resume from ampdresume.com, visit the
 [Postman collection](https://www.postman.com/universal-sunset-980198/missionmike/request/8ceygsv/getresume?ctx=documentation)
 and fire off the `getResume` request using the slug of your preferred user.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "openresume-theme",
+  "name": "@ampdresume/theme",
   "version": "0.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "openresume-theme",
+      "name": "@ampdresume/theme",
       "version": "0.1.11",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@openresume/theme",
+  "name": "@ampdresume/theme",
   "version": "0.1.11",
-  "description": "A theme package for OpenResume",
+  "description": "A theme package for Amp'd Resume",
   "main": "dist/exports.js",
   "module": "dist/exports.mjs",
   "types": "dist/exports.d.ts",
@@ -29,19 +29,19 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/missionmike/openresume-theme.git"
+    "url": "git+https://github.com/missionmike/ampdresume-theme.git"
   },
   "keywords": [
     "resume",
     "theme",
-    "openresume"
+    "ampdresume"
   ],
   "author": "Michael R. Dinerstein",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/missionmike/openresume-theme/issues"
+    "url": "https://github.com/missionmike/ampdresume-theme/issues"
   },
-  "homepage": "https://github.com/missionmike/openresume-theme#readme",
+  "homepage": "https://github.com/missionmike/ampdresume-theme#readme",
   "dependencies": {
     "@iconify/react": "^5.0.2",
     "@mui/base": "^5.0.0-beta.68",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/missionmike/ampdresume-theme.git"
+    "url": "git+https://github.com/mission-minded-llc/ampdresume-theme.git"
   },
   "keywords": [
     "resume",
@@ -39,9 +39,9 @@
   "author": "Michael R. Dinerstein",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/missionmike/ampdresume-theme/issues"
+    "url": "https://github.com/mission-minded-llc/ampdresume-theme/issues"
   },
-  "homepage": "https://github.com/missionmike/ampdresume-theme#readme",
+  "homepage": "https://github.com/mission-minded-llc/ampdresume-theme#readme",
   "dependencies": {
     "@iconify/react": "^5.0.2",
     "@mui/base": "^5.0.0-beta.68",

--- a/src/app/components/Footer.test.tsx
+++ b/src/app/components/Footer.test.tsx
@@ -21,8 +21,8 @@ describe("Footer", () => {
     render(<Footer />);
 
     // Check if main links and content are present
-    expect(screen.getByText("openresume.org")).toBeInTheDocument();
-    expect(screen.getByText(/OpenResume\. All rights reserved\./)).toBeInTheDocument();
+    expect(screen.getByText("ampdresume.com")).toBeInTheDocument();
+    expect(screen.getByText(/Amp'd Resume\. All rights reserved\./)).toBeInTheDocument();
 
     // Check if current year is included in the copyright text
     const currentYear = new Date().getFullYear().toString();

--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -37,10 +37,10 @@ export const Footer = () => {
           textAlign: "center",
         }}
       >
-        <MuiLink href="/">openresume.org</MuiLink>
+        <MuiLink href="/">ampdresume.com</MuiLink>
         <Box>
           <Typography variant="caption" sx={{ textAlign: "center" }}>
-            &copy; {new Date().getFullYear()} OpenResume. All rights reserved.
+            &copy; {new Date().getFullYear()} Amp&apos;d Resume. All rights reserved.
           </Typography>
         </Box>
       </Box>

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -8,24 +8,23 @@ describe("HomePage", () => {
     render(page);
 
     // Check main heading
-    expect(screen.getByRole("heading", { name: /OpenResume Themes/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /Amp'd Resume Themes/i })).toBeInTheDocument();
 
     // Check subheading
     expect(
-      screen.getByRole("heading", { name: /Customizable Open-Source Themes for OpenResume/i }),
+      screen.getByRole("heading", { name: /Customizable Open-Source Themes for Amp'd Resume/i }),
     ).toBeInTheDocument();
 
-    // Check OpenResume links
-    const openResumeLinks = screen.getAllByRole("link", { name: /OpenResume/i });
-    expect(openResumeLinks).toHaveLength(2);
-    openResumeLinks.forEach((link) => {
-      expect(link).toHaveAttribute("href", "https://www.openresume.org");
+    const ampdResumeLinks = screen.getAllByRole("link", { name: /Amp'd Resume/i });
+    expect(ampdResumeLinks).toHaveLength(2);
+    ampdResumeLinks.forEach((link) => {
+      expect(link).toHaveAttribute("href", "https://www.ampdresume.com");
       expect(link).toHaveAttribute("target", "_blank");
     });
 
     // Check GitHub repository link
     const githubLink = screen.getByRole("link", { name: /GitHub/i });
-    expect(githubLink).toHaveAttribute("href", "https://github.com/missionmike/openresume-theme");
+    expect(githubLink).toHaveAttribute("href", "https://github.com/missionmike/ampdresume-theme");
     expect(githubLink).toHaveAttribute("target", "_blank");
 
     // Check contribution section

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -24,7 +24,10 @@ describe("HomePage", () => {
 
     // Check GitHub repository link
     const githubLink = screen.getByRole("link", { name: /GitHub/i });
-    expect(githubLink).toHaveAttribute("href", "https://github.com/missionmike/ampdresume-theme");
+    expect(githubLink).toHaveAttribute(
+      "href",
+      "https://github.com/mission-minded-llc/ampdresume-theme",
+    );
     expect(githubLink).toHaveAttribute("target", "_blank");
 
     // Check contribution section

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -79,7 +79,7 @@ export default async function HomePage() {
         </Typography>
         <P>
           Visit the open-source repository on{" "}
-          <MuiLink href="https://github.com/missionmike/ampdresume-theme" target="_blank">
+          <MuiLink href="https://github.com/mission-minded-llc/ampdresume-theme" target="_blank">
             GitHub
           </MuiLink>
           .

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,9 +5,9 @@ import { MuiLink } from "@/components/MuiLink";
 import { P } from "@/app/components/Typography";
 import React from "react";
 
-const title = "OpenResume Themes | Build Your Free Interactive Resume Theme";
+const title = "Amp'd Resume Themes | Build Your Free Interactive Resume Theme";
 const description =
-  "OpenResume is a free interactive resume builder. Themes are customizable and open-source for all users to use.";
+  "Amp'd Resume is a free interactive resume builder. Themes are customizable and open-source for all users to use.";
 
 export const metadata: Metadata = {
   title: description,
@@ -49,7 +49,7 @@ export default async function HomePage() {
             typography: { sm: "h2", xs: "h4" },
           }}
         >
-          OpenResume Themes
+          Amp&apos;d Resume Themes
         </Typography>
         <Typography
           component="h2"
@@ -59,27 +59,27 @@ export default async function HomePage() {
           }}
         >
           Customizable Open-Source Themes for{" "}
-          <MuiLink href="https://www.openresume.org" target="_blank">
-            OpenResume
+          <MuiLink href="https://www.ampdresume.com" target="_blank">
+            Amp&apos;d Resume
           </MuiLink>
         </Typography>
         <P>
           This is a collection of themes for{" "}
-          <MuiLink href="https://www.openresume.org" target="_blank">
-            OpenResume
+          <MuiLink href="https://www.ampdresume.com" target="_blank">
+            Amp&apos;d Resume
           </MuiLink>{" "}
           that can be used to customize your resume and portfolio.
         </P>
         <P>
           Themes that are created by the community are listed here, and made available to all users
-          in the OpenResume platform.
+          in the Amp&apos;d Resume platform.
         </P>
         <Typography component="h3" variant="h4" sx={{ marginTop: 4, marginBottom: 2 }}>
           How can I contribute?
         </Typography>
         <P>
           Visit the open-source repository on{" "}
-          <MuiLink href="https://github.com/missionmike/openresume-theme" target="_blank">
+          <MuiLink href="https://github.com/missionmike/ampdresume-theme" target="_blank">
             GitHub
           </MuiLink>
           .

--- a/src/app/theme/[themeName]/page.test.tsx
+++ b/src/app/theme/[themeName]/page.test.tsx
@@ -20,13 +20,13 @@ describe("Theme Page", () => {
       const metadata = await generateMetadata({ params });
 
       expect(metadata.title).toBe(`Theme: ${themeName} ${titleSuffix}`);
-      expect(metadata.description).toBe(`This is the ${themeName} theme for OpenResume.`);
+      expect(metadata.description).toBe(`This is the ${themeName} theme for Amp'd Resume.`);
       expect(Array.isArray(metadata.authors) && metadata.authors[0]?.name).toBe(
         themeAuthor?.default,
       );
       expect(metadata.openGraph).toEqual({
         title: `Theme: ${themeName} ${titleSuffix}`,
-        description: `This is the ${themeName} theme for OpenResume.`,
+        description: `This is the ${themeName} theme for Amp'd Resume.`,
         images: [],
       });
     });

--- a/src/app/theme/[themeName]/page.tsx
+++ b/src/app/theme/[themeName]/page.tsx
@@ -12,7 +12,7 @@ export async function generateMetadata({
   const { themeName } = await params;
 
   const title = `Theme: ${themeName} ${titleSuffix}`;
-  const description = `This is the ${themeName} theme for OpenResume.`;
+  const description = `This is the ${themeName} theme for Amp'd Resume.`;
   const author = themeAuthor?.[themeName] || themeAuthor?.default;
   return {
     title,

--- a/src/app/theme/[themeName]/pdf/page.test.tsx
+++ b/src/app/theme/[themeName]/pdf/page.test.tsx
@@ -28,7 +28,7 @@ describe("PDF Theme Page", () => {
 
       expect(metadata).toEqual({
         title: `PDF Theme: default ${titleSuffix}`,
-        description: "This is the default theme for OpenResume.",
+        description: "This is the default theme for Amp'd Resume.",
         authors: [
           {
             name: themeAuthor?.default,
@@ -36,7 +36,7 @@ describe("PDF Theme Page", () => {
         ],
         openGraph: {
           title: `PDF Theme: default ${titleSuffix}`,
-          description: "This is the default theme for OpenResume.",
+          description: "This is the default theme for Amp'd Resume.",
           images: [],
         },
       });
@@ -48,7 +48,7 @@ describe("PDF Theme Page", () => {
 
       expect(metadata).toEqual({
         title: `PDF Theme: modern ${titleSuffix}`,
-        description: "This is the modern theme for OpenResume.",
+        description: "This is the modern theme for Amp'd Resume.",
         authors: [
           {
             name: themeAuthor?.modern || themeAuthor?.default,
@@ -56,7 +56,7 @@ describe("PDF Theme Page", () => {
         ],
         openGraph: {
           title: `PDF Theme: modern ${titleSuffix}`,
-          description: "This is the modern theme for OpenResume.",
+          description: "This is the modern theme for Amp'd Resume.",
           images: [],
         },
       });

--- a/src/app/theme/[themeName]/pdf/page.tsx
+++ b/src/app/theme/[themeName]/pdf/page.tsx
@@ -12,7 +12,7 @@ export async function generateMetadata({
   const { themeName } = await params;
 
   const title = `PDF Theme: ${themeName} ${titleSuffix}`;
-  const description = `This is the ${themeName} theme for OpenResume.`;
+  const description = `This is the ${themeName} theme for Amp'd Resume.`;
   const author = themeAuthor?.[themeName] || themeAuthor?.default;
   return {
     title,

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,6 +1,6 @@
 export { SOCIAL_MEDIA_PLATFORMS } from "./social";
 
-export const titleSuffix = "| OpenResume";
+export const titleSuffix = "| Amp'd Resume";
 
 // For the theme author name, the key is the theme name and the value is the author name.
 // Theme names should be lowercase, with dashes instead of spaces.

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,12 +1,12 @@
 /**
  * The types defined here are used to provide strong typing and structure for the data
- * used in various OpenResume themes.
+ * used in various Amp'd Resume themes.
  */
 
 /**
  * The appearance of the theme, which can be either "dark" or "light".
  * This value is used to determine the color scheme of the theme, and gets passed
- * in from the parent component. The parent OpenResume site has its own theme toggle,
+ * in from the parent component. The parent Amp'd Resume site has its own theme toggle,
  * which can be used to switch between the two appearances - this should NOT be
  * overridden by the theme.
  */
@@ -16,7 +16,7 @@ export type ThemeAppearance = "dark" | "light";
  * The name of the theme, which is used to determine the theme's appearance and
  * other settings. This value should be in slug format, with lowercase letters and
  * dashes instead of spaces. This value is used to determine which theme gets rendered
- * on the OpenResume site, and should be unique to each theme.
+ * on the Amp'd Resume site, and should be unique to each theme.
  */
 export type ThemeName = "default"; // Add more themes here, e.g. "default" | "my-theme" | "another-theme"
 
@@ -95,7 +95,7 @@ export interface Social {
 }
 
 /**
- * A Skill is a single global skill item defined by OpenResume's database. One or more of these
+ * A Skill is a single global skill item defined by Amp'd Resume's database. One or more of these
  * can be associated with a SkillForUser or SkillForProject, which are used to define a user's
  * skills and a project's skills, respectively.
  */


### PR DESCRIPTION
## Description

This PR supports the renaming of the app from "OpenResume" to "Amp'd Resume"

Additionally, this PR aims to publish a new `npm` package for `@ampdresume/theme` to replace the now-deprecated `@openresume/theme` package.