### PR TITLE
fix: revert the jsx prop.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Amp'd Resume Theme
 
-[![codecov](https://codecov.io/gh/missionmike/ampdresume-theme/graph/badge.svg?token=HGZ6NME2HH)](https://codecov.io/gh/missionmike/ampdresume-theme)
+[![codecov](https://codecov.io/gh/mission-minded-llc/ampdresume-theme/graph/badge.svg?token=HGZ6NME2HH)](https://codecov.io/gh/mission-minded-llc/ampdresume-theme)
 
 Anyone can contribute their own frontend theme design and implementation for
 [Amp'd Resume](https://www.ampdresume.com).

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {


### PR DESCRIPTION
I believe using `"preserve"` instead of `"react-jsx"` is causing React to not be bundled with the package, leading to:

<img width="526" alt="image" src="https://github.com/user-attachments/assets/344756dc-bb94-44b0-a867-69c23b4c3099" />
